### PR TITLE
fix: Make package name lowercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mparticle/web-mParticle-analytics-kit",
+  "name": "@mparticle/web-mparticle-analytics-kit",
   "version": "1.0.0",
   "main": "dist/mParticleAnalytics-Kit.common.js",
   "browser": "dist/mParticleAnalytics-Kit.iife.js",


### PR DESCRIPTION
I received an error publishing this.  It appears npm only allows fully lowercase package names.